### PR TITLE
fix: prevent crashing error if more closing tags than opening tags

### DIFF
--- a/source/ast.ts
+++ b/source/ast.ts
@@ -52,6 +52,9 @@ export class ASTBuilder extends Rule {
     });
 
     parser.on("endTag", (tag, attrs, selfClosing, loc) => {
+      if (current.parent === null) {
+        return;
+      }
       current = current.parent;
     });
 


### PR DESCRIPTION
**Make sure you check the following:**
* [x] you are making a pull request for the `develop` branch
* [x] you've ran `gulp test` and it passes the lint
** 'gulp test' doesn't work on Windows seemingly. I get a lot of errors.
** template-lint/node_modules/aurelia-pal-nodejs/dist/dom.d.ts(50,35): error TS1005: ',' expected. <- Got 100+ errors like this. Also got CRLF vs LF errors.
* [x] tests don't fail (except tests in 'failing.spec.ts')
** Uncertain... couldn't run them.

**Untested test case:**
```
t("avoid crash if too many closing tags", (done) => {
    var config: Config = new Config();
    var linter: AureliaLinter = new AureliaLinter(config);
    var html = `
        <template>
          <div>
            <section>
            </section>
          </div>
          </div>
        </template>`;
    linter.lint(html)
      .then((issues) => {
        // TODO: Jake: Run the test
        expect(issues.length).toBe(1);
        expect(issues[0].message).toBe("Need to see what error prints out and replace this text");
        done();
      });
  });
```