### PR TITLE
fix: update binding.ts and ast.ts to be compatible with newer typescript version

### DIFF
--- a/source/ast.ts
+++ b/source/ast.ts
@@ -121,13 +121,13 @@ export class FileLoc {
 export class ASTContext {
   name: string = null;
   type: ts.TypeNode = null;
-  typeDecl: ts.Declaration = null;
+  typeDecl: ts.NamedDeclaration = null;
   typeValue: Object = null;
 
   constructor(init?: {
     name?: string,
     type?: ts.TypeNode,
-    typeDecl?: ts.Declaration,
+    typeDecl?: ts.NamedDeclaration,
     typeValue?: Object
   }) {
     if (init)


### PR DESCRIPTION
Fixes the issue mentioned in https://github.com/aurelia/template-lint/issues/191, which caused the build to fail for this repo.